### PR TITLE
Adds toggle_visibility function

### DIFF
--- a/paraview_manager.py
+++ b/paraview_manager.py
@@ -577,6 +577,42 @@ class ParaViewManager:
             self.logger.error(f"Error toggling volume rendering: {str(e)}")
             return False, f"Error toggling volume rendering: {str(e)}", None
 
+    def toggle_visibility(self, enable=True):
+        """
+        Toggle visibility for the current source.
+        
+        Args:
+            enable (bool): Whether to enable (True) or disable (False) visibility of the current source.
+                          If True, shows the current source.
+                          If False, hides the current source.
+        
+        Returns:
+            tuple: (success, message, source_name)
+        """
+        try:
+            from paraview.simple import GetActiveView, SetActiveSource, GetDisplayProperties
+
+            if not GetActiveSource():
+                return False, "Error: No data selected. Load data first.", None
+
+            view = GetActiveView()
+            display = GetDisplayProperties(GetActiveSource(), view)
+            
+            if enable:
+                display.Visibility = 1
+                status_message = "Element was made visibile"
+            else:
+                display.Visibility = 0
+                status_message = "Rendering hidden (representation preserved)"
+
+            # Get the source name using the helper function
+            source_name = self._get_source_name(GetActiveSource())
+
+            return True, status_message, source_name
+
+        except Exception as e:
+            self.logger.error(f"Error toggling visibility: {str(e)}")
+            return False, f"Error toggling visibility: {str(e)}", None
     
     def color_by(self, field, component=-1):
         """

--- a/paraview_mcp_server.py
+++ b/paraview_mcp_server.py
@@ -176,6 +176,28 @@ def toggle_volume_rendering(enable: bool = True) -> str:
         return message
 
 @mcp.tool()
+def toggle_visibility(enable: bool = True) -> str:
+    """
+    Toggle the visibility for the active source.
+    
+    Args:
+        enable (bool): Whether to show (True) or hide (False) the active source.
+                      If True, makes the active source visible.
+                      If False, hides the active source but preserves the representation settings.
+    
+    Returns:
+        Status message
+    """
+       
+    success, message, source_name = pv_manager.toggle_visibility(enable)
+    if success:
+        # Return a user-friendly message that also includes the name
+        return f"{message}. Source registered as '{source_name}'."
+    else:
+        return message
+
+
+@mcp.tool()
 def set_active_source(name: str) -> str:
     """
     Set the active pipeline object by its name.
@@ -455,6 +477,7 @@ def list_commands() -> str:
         "create_isosurface: Create an isosurface visualization",
         "create_slice: Create a slice through the data",
         "toggle_volume_rendering: Enable or disable volume rendering",
+	"toggle_visibility: Enable or disable visibility for the active source",
         "set_active_source: Set the active pipeline object by name",
         "get_active_source_names_by_type: Get a list of sources filtered by type",
         "color_by: Color the visualization by a field",


### PR DESCRIPTION
Adds a function to toggle the visibility of the active pipeline element.
I was having an issue where I would make a cut or an isosurface but couldn't see it due to the rest of the data in the way. With this function, the AI can hide data to let users see underneath at what they actually want to look at.