### PR TITLE
Local MCP setup using ParaView.app + Python 3.12 venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ htmlcov/
 # Environment and virtual environment folders
 .env
 .venv/
+deps/
 env/
 venv/
 ENV/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ParaView MCP Server — bridges ParaView's visualization capabilities to LLMs via the Model Context Protocol. The server connects to a running `pvserver` instance over the network and exposes ParaView operations as MCP tools.
+
+## Architecture
+
+Three-layer client-server model:
+
+1. **pvserver** — ParaView's server process, runs on `localhost:11111` with `--multi-clients`
+2. **MCP Server** (this project) — connects to pvserver via `paraview.simple.Connect()`, exposes tools via FastMCP
+3. **Claude Code / Claude Desktop** — consumes MCP tools
+
+Two core files:
+- **`paraview_mcp_server.py`** — FastMCP tool definitions (thin wrappers that delegate to the manager)
+- **`paraview_manager.py`** — `ParaViewManager` class encapsulating all `paraview.simple` API interactions
+
+Launch infrastructure:
+- **`run_server.sh`** — sets `DYLD_FALLBACK_LIBRARY_PATH` for VTK dylibs, runs via venv Python
+- **`run_server.py`** — appends ParaView's Python path *after* venv packages (avoids shadowing pydantic's typing_extensions with ParaView's older version)
+
+## Adding New Tools
+
+Follow the existing pattern:
+
+1. Add a method to `ParaViewManager` in `paraview_manager.py` that returns a tuple `(success: bool, message: str, ...)`. Import from `paraview.simple` inside the method body.
+2. Add a `@mcp.tool()` function in `paraview_mcp_server.py` that calls the manager method and returns the message string.
+3. Add the tool to the `list_commands()` output.
+
+For dict/list parameters passed from the LLM, use typed signatures like `list[dict[str, float]]` and transform to the internal format in the MCP wrapper (see `edit_volume_opacity` and `set_color_map` for examples).
+
+## Running
+
+```bash
+# Terminal 1: Start pvserver
+/Applications/ParaView-6.0.1.app/Contents/bin/pvserver --multi-clients
+
+# ParaView GUI: File > Connect > localhost:11111
+
+# Terminal 2 (or via Claude Code MCP config): Start MCP server
+/Users/tomer/Documents/paraview_mcp/run_server.sh
+```
+
+Register with Claude Code:
+```bash
+claude mcp add-json ParaView '{"command":"/Users/tomer/Documents/paraview_mcp/run_server.sh","args":[]}' --scope user
+```
+
+## Key Design Decisions
+
+- **`original_source`**: The manager stores the first loaded data source separately. Volume rendering and some filters reference this to ensure they operate on the root data, not a derived filter.
+- **`_data_folder`**: Tracks the directory of loaded data so `save_contour_as_stl` exports to the same location.
+- **RAW file handling**: Parses dimensions and data type from the filename (e.g., `foot_256x256x256_uint8.raw`).
+- **ParaView 6.0.1 API**: Uses `Invert` (not the deprecated `InsideOut`) on the Clip filter.
+
+## Logging
+
+Logs to `~/paraview_logs/paraview_mcp_external.log` (INFO level, file + console).
+
+## Git
+
+Branch: `local-setup` (forked from LLNL/paraview_mcp). Uses conventional commits.

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,119 @@
+# ParaView MCP - Local Setup
+
+Local setup for [paraview_mcp](https://github.com/LLNL/paraview_mcp) on this machine.
+This diverges from the upstream README (which uses conda) because we already have
+ParaView 6.0.1 installed as a macOS app and don't have conda.
+
+## How it works
+
+The upstream approach installs ParaView via conda into a single Python environment
+alongside the MCP dependencies. We can't do that because:
+
+- No conda installed
+- ParaView 6.0.1 is already installed at `/Applications/ParaView-6.0.1.app`
+- ParaView's bundled `pvpython` is too stripped-down (no ssl, no pip, no tomllib)
+  to run the MCP server directly
+
+Instead, we use a standalone Python 3.12 venv for the MCP dependencies and load
+ParaView's Python packages from the .app bundle at runtime.
+
+### The path-ordering problem
+
+ParaView ships its own `typing_extensions.py` which is older than what `mcp` requires.
+If ParaView's Python path is *prepended* (via `PYTHONPATH`), it shadows the venv's version
+and breaks pydantic. The fix: *append* ParaView's path (via `sys.path.append` in
+`run_server.py`) so the venv's packages take precedence.
+
+### The native library problem
+
+ParaView's `.so` modules use `@executable_path/../Libraries` to find VTK dylibs.
+When running from the venv's Python (not pvpython), that path resolves wrong.
+The fix: set `DYLD_FALLBACK_LIBRARY_PATH` to ParaView's Libraries directory.
+Using `_FALLBACK_` (not `DYLD_LIBRARY_PATH`) avoids interfering with the venv
+Python's own standard library C extensions.
+
+## What was installed
+
+### Python 3.12 (via uv)
+
+```
+uv python install 3.12
+```
+
+### Venv + dependencies
+
+```
+uv venv --python 3.12 /Users/tomer/Documents/paraview_mcp/.venv
+uv pip install --python .venv/bin/python 'mcp[cli]' httpx Pillow
+```
+
+### Compatibility fix
+
+`paraview_mcp_server.py` line 57: changed `system_prompt=` to `instructions=`
+for mcp v1.26+ compatibility (upstream was written against an older mcp API).
+
+### Files added
+
+- `run_server.py` - Python wrapper that appends ParaView's package path to `sys.path`
+  then imports and runs the MCP server
+- `run_server.sh` - Shell launcher that sets `DYLD_FALLBACK_LIBRARY_PATH` and
+  execs `run_server.py` via the venv Python
+- `.venv/` - Python 3.12 virtual environment with MCP dependencies
+
+### Claude Code MCP registration
+
+```
+claude mcp add-json ParaView '{"command":"/Users/tomer/Documents/paraview_mcp/run_server.sh","args":[]}' --scope user
+```
+
+## Usage
+
+### 1. Start pvserver
+
+```
+pvs
+```
+
+This is an alias (defined in `~/.zshrc`) for:
+```
+/Applications/ParaView-6.0.1.app/Contents/bin/pvserver --multi-clients
+```
+
+Leave this running in a terminal.
+
+### 2. Connect the ParaView GUI
+
+- Open ParaView
+- File -> Connect
+- Connect to `localhost:11111` (the default)
+
+### 3. Start a Claude Code session
+
+The ParaView MCP server is registered at user scope and will be available in any
+new Claude Code session. The MCP server connects to pvserver automatically on startup.
+
+### Available MCP tools
+
+Once connected, Claude has access to these ParaView tools:
+
+- `load_data` - Load VTK, EXODUS, CSV, RAW files
+- `create_source` - Create primitives (Sphere, Cone, Cylinder, Plane, Box)
+- `create_isosurface` - Isosurface at specified values
+- `create_slice` - Planar slices through volumes
+- `create_streamline` - Streamlines from vector fields
+- `warp_by_vector` - Deform geometry by vector field
+- `toggle_volume_rendering` - Enable/disable volume rendering
+- `toggle_visibility` - Show/hide sources
+- `set_representation_type` - Surface, Wireframe, Points
+- `color_by` - Color by data field
+- `set_color_map` - Custom color transfer functions
+- `edit_volume_opacity` - Opacity transfer functions
+- `set_active_source` - Select pipeline objects by name
+- `get_active_source_names_by_type` - Filter sources by type
+- `get_pipeline` - Display pipeline structure
+- `get_available_arrays` - List data arrays
+- `compute_surface_area` - Calculate mesh surface area
+- `plot_over_line` - Sample data along a line
+- `get_screenshot` - Capture viewport image (visual feedback loop)
+- `rotate_camera` / `reset_camera` - Adjust view
+- `save_contour_as_stl` - Export surfaces as STL

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Click the image below to watch the video:
 
 ## Installation
 
+The upstream installation uses conda. For a non-conda setup using an existing ParaView.app installation, see [LOCAL_SETUP.md](LOCAL_SETUP.md).
+
 ```shell
 git clone https://github.com/LLNL/paraview_mcp.git
 cd paraview_mcp

--- a/paraview_manager.py
+++ b/paraview_manager.py
@@ -1321,3 +1321,226 @@ class ParaViewManager:
         except Exception as e:
             self.logger.error(f"Error creating warp by vector: {str(e)}")
             return False, f"Error creating warp by vector: {str(e)}", None
+
+    def rename_source(self, new_name):
+        """
+        Rename the active source in the pipeline browser.
+
+        Args:
+            new_name (str): The new name for the active source.
+
+        Returns:
+            tuple: (success: bool, message: str)
+        """
+        try:
+            from paraview.simple import GetActiveSource, RenameSource
+
+            source = GetActiveSource()
+            if not source:
+                return False, "Error: No active source to rename."
+
+            old_name = self._get_source_name(source)
+            RenameSource(new_name, source)
+            return True, f"Renamed '{old_name}' to '{new_name}'."
+        except Exception as e:
+            self.logger.error(f"Error renaming source: {str(e)}")
+            return False, f"Error renaming source: {str(e)}"
+
+    def delete_source(self, name=None):
+        """
+        Delete a source from the pipeline.
+
+        Args:
+            name (str, optional): Name of the source to delete.
+                                  If None, deletes the active source.
+
+        Returns:
+            tuple: (success: bool, message: str)
+        """
+        try:
+            from paraview.simple import (
+                GetActiveSource, GetSources, SetActiveSource, Delete
+            )
+
+            if name is not None:
+                # Find the source by name
+                sources_dict = GetSources()
+                target = None
+                for (source_key, proxy) in sources_dict.items():
+                    if source_key[0] == name:
+                        target = proxy
+                        break
+                if target is None:
+                    return False, f"No source found with the name '{name}'."
+                SetActiveSource(target)
+                Delete(target)
+                return True, f"Deleted source '{name}'."
+            else:
+                source = GetActiveSource()
+                if not source:
+                    return False, "Error: No active source to delete."
+                source_name = self._get_source_name(source)
+                Delete(source)
+                return True, f"Deleted source '{source_name}'."
+        except Exception as e:
+            self.logger.error(f"Error deleting source: {str(e)}")
+            return False, f"Error deleting source: {str(e)}"
+
+    def create_clip(self, origin_x=None, origin_y=None, origin_z=None,
+                    normal_x=1, normal_y=0, normal_z=0, inside_out=False):
+        """
+        Create a clip through the active source.
+
+        Args:
+            origin_x, origin_y, origin_z: Coordinates for the clip plane origin.
+                                          If None, uses the dataset center.
+            normal_x, normal_y, normal_z: Normal of the clip plane (default: [1, 0, 0]).
+            inside_out (bool): If True, keep the half behind the plane instead of in front.
+
+        Returns:
+            tuple: (success: bool, message: str, clip_filter, clip_name: str)
+        """
+        try:
+            from paraview.simple import (
+                GetActiveView, GetActiveSource, Clip, Show
+            )
+
+            base_source = GetActiveSource()
+            if not base_source:
+                return False, "Error: No active source. Load data first.", None, ""
+
+            if origin_x is not None and origin_y is not None and origin_z is not None:
+                origin = [origin_x, origin_y, origin_z]
+            else:
+                info = base_source.GetDataInformation()
+                bounds = info.GetBounds()
+                origin = [
+                    (bounds[0] + bounds[1]) / 2,
+                    (bounds[2] + bounds[3]) / 2,
+                    (bounds[4] + bounds[5]) / 2
+                ]
+
+            normal = [normal_x, normal_y, normal_z]
+
+            clip_filter = Clip(Input=base_source)
+            clip_filter.ClipType = 'Plane'
+            clip_filter.ClipType.Origin = origin
+            clip_filter.ClipType.Normal = normal
+            clip_filter.Invert = 1 if inside_out else 0
+
+            view = GetActiveView()
+            Show(clip_filter, view)
+
+            clip_name = self._get_source_name(clip_filter)
+
+            message = (
+                f"Created clip with origin {origin} and normal {normal}. "
+                f"InsideOut={inside_out}. Clip name is: {clip_name}"
+            )
+            return True, message, clip_filter, clip_name
+        except Exception as e:
+            self.logger.error(f"Error creating clip: {str(e)}")
+            return False, f"Error creating clip: {str(e)}", None, ""
+
+    def create_threshold(self, field, lower=None, upper=None, field_association="CELLS"):
+        """
+        Create a threshold filter on the active source.
+
+        Args:
+            field (str): The scalar field to threshold by.
+            lower (float, optional): Lower threshold value. If None, uses the field minimum.
+            upper (float, optional): Upper threshold value. If None, uses the field maximum.
+            field_association (str): 'CELLS' or 'POINTS' (default: 'CELLS').
+
+        Returns:
+            tuple: (success: bool, message: str, threshold_filter, threshold_name: str)
+        """
+        try:
+            from paraview.simple import (
+                GetActiveView, GetActiveSource, Threshold, Show
+            )
+
+            base_source = GetActiveSource()
+            if not base_source:
+                return False, "Error: No active source. Load data first.", None, ""
+
+            threshold_filter = Threshold(Input=base_source)
+            threshold_filter.Scalars = (field_association, field)
+
+            if lower is not None:
+                threshold_filter.LowerThreshold = lower
+            if upper is not None:
+                threshold_filter.UpperThreshold = upper
+
+            view = GetActiveView()
+            Show(threshold_filter, view)
+
+            threshold_name = self._get_source_name(threshold_filter)
+
+            bounds_str = f"[{lower if lower is not None else 'min'}, {upper if upper is not None else 'max'}]"
+            message = (
+                f"Created threshold on '{field}' ({field_association}) "
+                f"with range {bounds_str}. Threshold name is: {threshold_name}"
+            )
+            return True, message, threshold_filter, threshold_name
+        except Exception as e:
+            self.logger.error(f"Error creating threshold: {str(e)}")
+            return False, f"Error creating threshold: {str(e)}", None, ""
+
+    def exec_python(self, code):
+        """
+        Execute arbitrary Python code in the ParaView Python environment.
+
+        Args:
+            code (str): Python code to execute.
+
+        Returns:
+            tuple: (success: bool, output: str)
+        """
+        import io
+        import sys
+        import traceback
+
+        stdout_capture = io.StringIO()
+        stderr_capture = io.StringIO()
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+
+        try:
+            sys.stdout = stdout_capture
+            sys.stderr = stderr_capture
+
+            # Build a namespace with paraview.simple available
+            exec_globals = {"__builtins__": __builtins__}
+            try:
+                import paraview.simple as pvs
+                exec_globals["paraview"] = __import__("paraview")
+                exec_globals["pvs"] = pvs
+                # Also inject all of paraview.simple for convenience
+                for name in dir(pvs):
+                    if not name.startswith("_"):
+                        exec_globals[name] = getattr(pvs, name)
+            except ImportError:
+                pass
+
+            exec(code, exec_globals)
+
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+            stdout_val = stdout_capture.getvalue()
+            stderr_val = stderr_capture.getvalue()
+            output = ""
+            if stdout_val:
+                output += stdout_val
+            if stderr_val:
+                output += stderr_val
+            if not output:
+                output = "(executed successfully, no output)"
+
+            return True, output
+        except Exception as e:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+            tb = traceback.format_exc()
+            return False, f"Error:\n{tb}"

--- a/paraview_mcp_server.py
+++ b/paraview_mcp_server.py
@@ -54,7 +54,7 @@ logger = logging.getLogger("pv_external_mcp")
 pv_manager = ParaViewManager()
 
 # Initialize FastMCP server for Claude Desktop integration with default prompt
-mcp = FastMCP("ParaView", system_prompt=default_prompt)
+mcp = FastMCP("ParaView", instructions=default_prompt)
 
 # ============================================================================
 # MCP Tools for ParaView
@@ -531,6 +531,96 @@ def warp_by_vector(vector_field: str = None, scale_factor: float = 1.0) -> str:
     return message
 
 @mcp.tool()
+def rename_source(new_name: str) -> str:
+    """
+    Rename the active source in the pipeline browser.
+
+    Args:
+        new_name: The new display name for the active source.
+
+    Returns:
+        Status message
+    """
+    success, message = pv_manager.rename_source(new_name)
+    return message
+
+@mcp.tool()
+def delete_source(name: str = None) -> str:
+    """
+    Delete a source from the pipeline.
+
+    Args:
+        name: Name of the source to delete. If not provided, deletes the active source.
+
+    Returns:
+        Status message
+    """
+    success, message = pv_manager.delete_source(name)
+    return message
+
+@mcp.tool()
+def create_clip(origin_x: float = None, origin_y: float = None, origin_z: float = None,
+                normal_x: float = 1, normal_y: float = 0, normal_z: float = 0,
+                inside_out: bool = False) -> str:
+    """
+    Create a clip (half-space cut) through the active source.
+
+    Args:
+        origin_x, origin_y, origin_z: Clip plane origin. If None, uses dataset center.
+        normal_x, normal_y, normal_z: Clip plane normal (default [1, 0, 0]).
+        inside_out: If True, keep the half behind the plane instead of in front.
+
+    Returns:
+        Status message
+    """
+    success, message, _, clip_name = pv_manager.create_clip(
+        origin_x, origin_y, origin_z,
+        normal_x, normal_y, normal_z,
+        inside_out
+    )
+    return message
+
+@mcp.tool()
+def create_threshold(field: str, lower: float = None, upper: float = None,
+                     field_association: str = "CELLS") -> str:
+    """
+    Create a threshold filter on the active source, keeping only cells/points
+    where the field value falls within the specified range.
+
+    Args:
+        field: The scalar field to threshold by.
+        lower: Lower threshold value. If None, uses field minimum.
+        upper: Upper threshold value. If None, uses field maximum.
+        field_association: 'CELLS' or 'POINTS' (default: 'CELLS').
+
+    Returns:
+        Status message
+    """
+    success, message, _, threshold_name = pv_manager.create_threshold(
+        field, lower, upper, field_association
+    )
+    return message
+
+@mcp.tool()
+def exec_python(code: str) -> str:
+    """
+    Execute arbitrary Python code in the ParaView Python environment.
+    All of paraview.simple is available in the namespace (e.g. GetActiveSource,
+    Show, Render, etc.) as well as via the 'pvs' alias.
+
+    Use print() to return results. If no output is printed, a success
+    confirmation is returned.
+
+    Args:
+        code: Python code to execute.
+
+    Returns:
+        Captured stdout/stderr output, or error traceback.
+    """
+    success, output = pv_manager.exec_python(code)
+    return output
+
+@mcp.tool()
 def list_commands() -> str:
     """
     List all available commands in this ParaView MCP server.
@@ -554,6 +644,11 @@ def list_commands() -> str:
         "get_pipeline: Get the current pipeline structure",
         "get_available_arrays: Get available data arrays",
         "create_streamline: Create stream line visualization",
+        "rename_source: Rename the active source in the pipeline browser",
+        "delete_source: Delete a source from the pipeline",
+        "create_clip: Create a clip (half-space cut) through the active source",
+        "create_threshold: Threshold filter by field value range",
+        "exec_python: Execute arbitrary Python code in ParaView's Python environment",
         "compute_surface_area: Compute the surface area of the active surface",
         "save_contour_as_stl: Save the active surface as STL",
         "get_screenshot: Capture a screenshot and display it in chat",

--- a/run_server.py
+++ b/run_server.py
@@ -1,0 +1,8 @@
+"""Wrapper that appends ParaView's Python path (so it doesn't shadow venv packages)
+then runs the MCP server."""
+import sys
+sys.path.append("/Applications/ParaView-6.0.1.app/Contents/Python")
+
+# Now import and run the server's main
+from paraview_mcp_server import main
+main()

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Launcher for ParaView MCP server
+# Sets up the library path so ParaView's VTK modules can load from a standalone Python 3.12
+
+export DYLD_FALLBACK_LIBRARY_PATH=/Applications/ParaView-6.0.1.app/Contents/Libraries
+exec /Users/tomer/Documents/paraview_mcp/.venv/bin/python \
+    /Users/tomer/Documents/paraview_mcp/run_server.py \
+    "$@"


### PR DESCRIPTION
## Summary

- Adds a non-conda MCP server setup that reuses the existing ParaView 6.0.1.app installation with a standalone Python 3.12 venv for MCP dependencies
- Adds new ParaViewManager methods: rename_source, delete_source, create_clip, create_threshold, exec_python
- Adds CLAUDE.md for Claude Code project context

## Details

The upstream setup requires conda to install ParaView + MCP deps in one environment. This setup instead:
- Uses a Python 3.12 venv (via uv) for mcp/httpx/Pillow
- Appends ParaView.app's Python path at runtime (avoiding typing_extensions shadowing)
- Sets `DYLD_FALLBACK_LIBRARY_PATH` for VTK native library resolution
- Fixes `system_prompt` → `instructions` for mcp v1.26+ compatibility

See [LOCAL_SETUP.md](LOCAL_SETUP.md) for full documentation.

## Test plan

- [ ] Start pvserver: `pvs` (alias for `/Applications/ParaView-6.0.1.app/Contents/bin/pvserver --multi-clients`)
- [ ] Connect ParaView GUI to localhost:11111
- [ ] Start a new Claude Code session and verify ParaView MCP tools are available
- [ ] Load a VTK file via MCP and take a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)